### PR TITLE
Reverting #37426

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -42,11 +42,6 @@
 		active_hotspot.just_spawned = (current_cycle < SSair.times_fired)
 			//remove just_spawned protection if no longer processing this cell
 		SSair.add_to_active(src, 0)
-	else
-		var/datum/gas_mixture/heating = air_contents.remove_ratio(exposed_volume/air_contents.volume)
-		heating.temperature = exposed_temperature
-		heating.react()
-		assume_air(heating)
 	return igniting
 
 //This is the icon for fire on turfs, also helps for nurturing small fires until they are full tile


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/37426
This causes too many problems, simply using an inducer to recharge a machine makes a room hot enough to burn you. The idea's fine but it needs to be very carefully managed, and probably work on a whitelist basis, as a huge number of theoretical heat sources in the game would be utterly negligible, such as lighters, matches, lit cigarettes, and simple sparks.